### PR TITLE
WIP: sd_admissible

### DIFF
--- a/src/bflow.jl
+++ b/src/bflow.jl
@@ -124,14 +124,18 @@ function num2spin(σ)
    error("illegal integer value for num2spin")
 end
 
+
 """
-This function return a nice version of spec.
+This function returns a nice version of spec.
 """
-function displayspec(spec, spec1p)
+function displayspec(wf::BFwf)
+   K = length(wf.polys)
+   spec1p = [ (k, σ) for σ in [1, 2, 3] for k in 1:K]
+   spec1p = sort(spec1p, by = b -> b[1])
    _getnicespec = l -> (l[1], num2spin(l[2]))
    nicespec = []
-   for k = 1:length(spec)
-      push!(nicespec, _getnicespec.([spec1p[spec[k][j]] for j = 1:length(spec[k])]))
+   for k = 1:length(wf.spec)
+      push!(nicespec, _getnicespec.([spec1p[wf.spec[k][j]] for j = 1:length(wf.spec[k])]))
    end
    return nicespec
 end

--- a/src/bflow.jl
+++ b/src/bflow.jl
@@ -35,6 +35,7 @@ end
 function BFwf(Nel::Integer, polys; totdeg = length(polys), 
                      ν = 3, T = Float64, 
                      trans = identity, 
+                     sd_admissible = bb -> (true),
                      #envelope = envelopefcn(x -> x, rand()))
                      envelope = envelopefcn(x -> sqrt(1 + x^2), 0.5))
    # 1-particle spec 
@@ -45,8 +46,8 @@ function BFwf(Nel::Integer, polys; totdeg = length(polys),
    pooling = PooledSparseProduct(spec1p)
    # generate the many-particle spec 
    tup2b = vv -> [ spec1p[v] for v in vv[vv .> 0]  ]
-   admissible = bb -> (length(bb) == 0) || (sum(b[1] - 1 for b in bb ) <= totdeg)
-   
+   default_admissible = bb -> (length(bb) == 0) || (sum(b[1] - 1 for b in bb ) <= totdeg)
+   admissible = bb -> (default_admissible(bb) && sd_admissible(bb))
    specAA = gensparse(; NU = ν, tup2b = tup2b, admissible = admissible,
                         minvv = fill(0, ν), 
                         maxvv = fill(length(spec1p), ν), 

--- a/src/bflow.jl
+++ b/src/bflow.jl
@@ -36,8 +36,7 @@ function BFwf(Nel::Integer, polys; totdeg = length(polys),
                      ν = 3, T = Float64, 
                      trans = identity, 
                      sd_admissible = bb -> (true),
-                     #envelope = envelopefcn(x -> x, rand()))
-                     envelope = envelopefcn(x -> sqrt(1 + x^2), 0.5))
+                     envelope = envelopefcn(x -> sqrt(1 + x^2), rand()))
    # 1-particle spec 
    K = length(polys)
    spec1p = [ (k, σ) for σ in [1, 2, 3] for k in 1:K]  # (1, 2, 3) = (∅, ↑, ↓);
@@ -47,14 +46,18 @@ function BFwf(Nel::Integer, polys; totdeg = length(polys),
    # generate the many-particle spec 
    tup2b = vv -> [ spec1p[v] for v in vv[vv .> 0]  ]
    default_admissible = bb -> (length(bb) == 0) || (sum(b[1] - 1 for b in bb ) <= totdeg)
-   admissible = bb -> (default_admissible(bb) && sd_admissible(bb))
-   specAA = gensparse(; NU = ν, tup2b = tup2b, admissible = admissible,
+   
+   specAA = gensparse(; NU = ν, tup2b = tup2b, admissible = default_admissible,
                         minvv = fill(0, ν), 
                         maxvv = fill(length(spec1p), ν), 
                         ordered = true)
    
-   spec = [ vv[vv .> 0] for vv in specAA if !(isempty(vv[vv .> 0]))]
    
+   spec = [ vv[vv .> 0] for vv in specAA if !(isempty(vv[vv .> 0]))]
+
+   # further restrict
+   spec = [t for t in spec if sd_admissible([spec1p[t[j]] for j = 1:length(t)])]
+
    corr1 = SparseSymmProd(spec; T = Float64)
    corr = corr1.dag   
 
@@ -128,7 +131,7 @@ function displayspec(spec, spec1p)
    _getnicespec = l -> (l[1], num2spin(l[2]))
    nicespec = []
    for k = 1:length(spec)
-      push!(nicespec, _getnicespec.([spec1p[spec[k][j]] for j in length(spec[k])]))
+      push!(nicespec, _getnicespec.([spec1p[spec[k][j]] for j = 1:length(spec[k])]))
    end
    return nicespec
 end

--- a/test/compare_bflow.jl
+++ b/test/compare_bflow.jl
@@ -29,6 +29,6 @@ for i = 1:5
    wf.W[:, i] = PP[i][2:end] # the first entry of PP[i] is the extra constant
 end
 println("ACESchrodinger.BFwf - ACEpsi.BFwf: ", wf(X, Σ) - refval)
-#spec1p = [ (k, σ) for σ in [1, 2, 3] for k in 1:length(polys) ]  # (1, 2, 3) = (∅, ↑, ↓);
-
-# @show displayspec(wf.spec, spec1p)
+spec1p = [ (k, σ) for σ in [1, 2, 3] for k in 1:length(polys) ]  # (1, 2, 3) = (∅, ↑, ↓);
+spec1p = sort(spec1p, by = b->b[1])
+@show displayspec(wf.spec, spec1p)

--- a/test/example_admissiible.jl
+++ b/test/example_admissiible.jl
@@ -1,15 +1,24 @@
 using Polynomials4ML, ACEcore, ACEpsi, ACEbase, Printf
-using ACEpsi: BFwf, gradient, evaluate, laplacian, envelopefcn
+using ACEpsi: BFwf, gradient, evaluate, laplacian, envelopefcn, displayspec
 using LinearAlgebra
 using BenchmarkTools
 using JSON
 const ↑, ↓, ∅ = '↑','↓','∅'
 Σ = [↑, ↑, ↑, ↓, ↓];
 Nel = 5
-polys = legendre_basis(10)
-MaxDeg = [10, 4]
-wf = BFwf(Nel, polys; ν=2, sd_admissible = bb -> (length(bb) == 0 || all([bb[i][1] < MaxDeg[i] for i = 1:length(bb)])))
+polys = legendre_basis(16)
+MaxDeg = [16, 5]
 
-X = 2 * rand(Nel) .- 1
-wf(X, Σ)
-g = gradient(wf, X, Σ)
+
+test_ad = bb -> (@show bb; @show all([bb[i][1] < MaxDeg[i] for i = 1:length(bb)]); (length(bb) == 0 || all([bb[i][1] <= MaxDeg[length(bb)] for i = 1:length(bb)])))
+wf = BFwf(Nel, polys; ν=2, sd_admissible = test_ad)
+
+K = length(wf.polys)
+spec1p = [ (k, σ) for σ in [1, 2, 3] for k in 1:K]
+spec1p = sort(spec1p,  by = b -> b[1])
+LL = displayspec(wf.spec, spec1p)
+@show size(LL)
+for i = 1:length(LL)
+    @show LL[i]
+end
+@show length(wf.spec)

--- a/test/example_admissiible.jl
+++ b/test/example_admissiible.jl
@@ -1,0 +1,15 @@
+using Polynomials4ML, ACEcore, ACEpsi, ACEbase, Printf
+using ACEpsi: BFwf, gradient, evaluate, laplacian, envelopefcn
+using LinearAlgebra
+using BenchmarkTools
+using JSON
+const ↑, ↓, ∅ = '↑','↓','∅'
+Σ = [↑, ↑, ↑, ↓, ↓];
+Nel = 5
+polys = legendre_basis(10)
+MaxDeg = [10, 4]
+wf = BFwf(Nel, polys; ν=2, sd_admissible = bb -> (length(bb) == 0 || all([bb[i][1] < MaxDeg[i] for i = 1:length(bb)])))
+
+X = 2 * rand(Nel) .- 1
+wf(X, Σ)
+g = gradient(wf, X, Σ)

--- a/test/test_admissiible.jl
+++ b/test/test_admissiible.jl
@@ -12,10 +12,9 @@ MaxDeg = [16, 5]
 
 test_ad = bb -> (@show bb; @show all([bb[i][1] < MaxDeg[i] for i = 1:length(bb)]); (length(bb) == 0 || all([bb[i][1] <= MaxDeg[length(bb)] for i = 1:length(bb)])))
 wf = BFwf(Nel, polys; ν=2, sd_admissible = test_ad)
-K = length(wf.polys)
-spec1p = [ (k, σ) for σ in [1, 2, 3] for k in 1:K]
-spec1p = sort(spec1p,  by = b -> b[1])
-LL = displayspec(wf.spec, spec1p)
+@show length(wf.polys)
+LL = displayspec(wf)
+@show LL
 for i = 1:length(LL)
     @show LL[i]
 end

--- a/test/test_admissiible.jl
+++ b/test/test_admissiible.jl
@@ -12,13 +12,10 @@ MaxDeg = [16, 5]
 
 test_ad = bb -> (@show bb; @show all([bb[i][1] < MaxDeg[i] for i = 1:length(bb)]); (length(bb) == 0 || all([bb[i][1] <= MaxDeg[length(bb)] for i = 1:length(bb)])))
 wf = BFwf(Nel, polys; ν=2, sd_admissible = test_ad)
-
 K = length(wf.polys)
 spec1p = [ (k, σ) for σ in [1, 2, 3] for k in 1:K]
 spec1p = sort(spec1p,  by = b -> b[1])
 LL = displayspec(wf.spec, spec1p)
-@show size(LL)
 for i = 1:length(LL)
     @show LL[i]
 end
-@show length(wf.spec)


### PR DESCRIPTION
There are mainly two updates from this pr:

1. a sd_admissible argument is added to the BFwf, which allows user to define a function `sd_admissible(bb:Vector{Tuple{Int64, Int64}}) -> Bool `
only ACE basis that has specification `bb` with 
`sd_admissible(bb) == True` 
is included in the BFwf.

This update should be compatible with previous implementation.

2. A minor fix on a more natural implementation on displayspec. The previous strange implementation is removed.

For both of the updates, a testing file is created at /test/test_admissible.jl